### PR TITLE
Code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.egg-info/
 **/dist/
 saves/
+/.idea

--- a/asciifarm/client/connection.py
+++ b/asciifarm/client/connection.py
@@ -10,6 +10,8 @@ class Connection:
             sockType = socket.AF_UNIX
         elif socketType == "inet":
             sockType = socket.AF_INET
+        else:
+            raise ValueError("Invalid socket type: %r" % (socketType,))
         self.sock = socket.socket(sockType, socket.SOCK_STREAM)
     
     def connect(self, address):

--- a/asciifarm/client/connection.py
+++ b/asciifarm/client/connection.py
@@ -21,7 +21,8 @@ class Connection:
                 data = receive(self.sock)
             except Exception as err:
                 onError(err)
-            callback(data)
+            else:
+                callback(data)
     
     def send(self, message):
         send(self.sock, bytes(message, 'utf-8'))

--- a/asciifarm/client/display/fieldpad.py
+++ b/asciifarm/client/display/fieldpad.py
@@ -29,14 +29,14 @@ class FieldPad:
     def changeCell(self, x, y, sprites):
         """ sprites must always have at least one element """
         char, colour, bgcolour = sprites[0]
-        if bgcolour == None:
+        if bgcolour is None:
             for (ch, co, bg) in sprites:
-                if bg != None:
+                if bg is not None:
                     bgcolour = bg
                     break
             else:
                 bgcolour = 0
-        if colour != None and self.colours:
+        if colour is not None and self.colours:
             self.pad.addstr(y, x*self.charSize, char, self.colours.get(colour, bgcolour))
         else:
             self.pad.addstr(y, x*self.charSize, char)

--- a/asciifarm/client/main.py
+++ b/asciifarm/client/main.py
@@ -57,7 +57,7 @@ def main(argv=None):
         keybindings = kf.read()
     
     address = args.address
-    if address == None:
+    if address is None:
         address = defaultAdresses[args.socket]
     if args.socket == "abstract":
         address = '\0' + address

--- a/asciifarm/common/utils.py
+++ b/asciifarm/common/utils.py
@@ -27,7 +27,7 @@ def concat(arr):
 
 
 def writeFileSafe(filename, data, tempname=None):
-    if tempname == None:
+    if tempname is None:
         tempname = filename + ".tempfile"
     with open(tempname, 'w') as f:
         f.write(data)

--- a/asciifarm/server/components/build.py
+++ b/asciifarm/server/components/build.py
@@ -5,7 +5,13 @@ from .component import Component
 class Build(Component):
     """ item type for item that can be placed on the map to become something more static (like buildable walls or crops)"""
     
-    def __init__(self, objType, objArgs=[], objKwargs={}, flagsNeeded=set()):
+    def __init__(self, objType, objArgs=None, objKwargs=None, flagsNeeded=None):
+        if objArgs is None:
+            objArgs = []
+        if objKwargs is None:
+            objKwargs = {}
+        if flagsNeeded is None:
+            flagsNeeded = set()
         self.buildType = objType
         self.buildArgs = objArgs
         self.buildKwargs = objKwargs

--- a/asciifarm/server/components/component.py
+++ b/asciifarm/server/components/component.py
@@ -16,6 +16,6 @@ class Component:
     
     @classmethod
     def fromJSON(cls, data=None):
-        if data == None:
+        if data is None:
             return cls()
         return cls(**data)

--- a/asciifarm/server/components/equipment.py
+++ b/asciifarm/server/components/equipment.py
@@ -6,7 +6,9 @@ from ..entity import Entity
 class Equipment(Component):
     
     
-    def __init__(self, slots={}):
+    def __init__(self, slots=None):
+        if slots is None:
+            slots = {}
         self.slots = {key: None for key in slots}
         self.owner = None
         for slot, item in slots.items():

--- a/asciifarm/server/components/equippable.py
+++ b/asciifarm/server/components/equippable.py
@@ -5,7 +5,9 @@ from .component import Component
 class Equippable(Component):
     """ item type for item that can be placed on the map to become something more static (like buildable walls or crops)"""
     
-    def __init__(self, slot, stats={}):
+    def __init__(self, slot, stats=None):
+        if stats is None:
+            stats = {}
         self.slot = slot
         self.stats = stats
     

--- a/asciifarm/server/components/grow.py
+++ b/asciifarm/server/components/grow.py
@@ -7,8 +7,11 @@ from .component import Component
 class Growing(Component):
     
     
-    def __init__(self, nextStage, duration, stepsPassed=None, nextArgs=[], nextKwargs={}):
-        
+    def __init__(self, nextStage, duration, stepsPassed=None, nextArgs=None, nextKwargs=None):
+        if nextArgs is None:
+            nextArgs = []
+        if nextKwargs is None:
+            nextKwargs = {}
         self.nextStage = nextStage
         self.duration = duration if stepsPassed != None else int(random.triangular(duration/2, duration*2, duration))
         self.stepsPassed = stepsPassed or 0

--- a/asciifarm/server/components/grow.py
+++ b/asciifarm/server/components/grow.py
@@ -13,7 +13,7 @@ class Growing(Component):
         if nextKwargs is None:
             nextKwargs = {}
         self.nextStage = nextStage
-        self.duration = duration if stepsPassed != None else int(random.triangular(duration/2, duration*2, duration))
+        self.duration = duration if stepsPassed is not None else int(random.triangular(duration/2, duration*2, duration))
         self.stepsPassed = stepsPassed or 0
         self.nextArgs = nextArgs
         self.nextKwargs = nextKwargs

--- a/asciifarm/server/components/inputcontroller.py
+++ b/asciifarm/server/components/inputcontroller.py
@@ -67,19 +67,19 @@ class InputController(Component):
     
     def do_take(self, rank):
         objects = self.owner.getNearObjects()
-        if rank != None:
+        if rank is not None:
             if rank not in range(len(objects)):
                 return
             objects = [objects[rank]]
         for obj in objects:
-            if obj.getComponent("item") != None and self.inventory.canAdd(obj):
+            if obj.getComponent("item") is not None and self.inventory.canAdd(obj):
                 self.owner.trigger("take", obj)
                 obj.remove()
                 break
     
     def do_drop(self, rank):
         items = self.inventory.getItems()
-        if rank == None:
+        if rank is None:
             rank = 0
         if rank not in range(len(items)):
             return
@@ -90,7 +90,7 @@ class InputController(Component):
         
     def do_use(self, rank):
         items = self.inventory.getItems()
-        if rank == None:
+        if rank is None:
             rank = 0
         if rank not in range(len(items)):
             return
@@ -99,37 +99,37 @@ class InputController(Component):
     
     def do_unequip(self, rank):
         slots = sorted(self.equipment.getSlots().items())
-        if rank != None:
+        if rank is not None:
             if rank not in range(len(slots)):
                 return
             slots = [slots[rank]]
         for (slot, item) in slots:
-            if item != None and self.inventory.canAdd(item):
+            if item is not None and self.inventory.canAdd(item):
                 self.equipment.unEquip(slot)
                 self.owner.trigger("take", item)
     
     def do_interact(self, rank):
         nearPlaces = self.owner.getGround().getNeighbours()
         objects = self.owner.getNearObjects()
-        if rank != None:
+        if rank is not None:
             if rank not in range(len(objects)):
                 return
             objects = [objects[rank]]
         for obj in objects:
-            if obj.getComponent("interact") != None:
+            if obj.getComponent("interact") is not None:
                 obj.getComponent("interact").interact(self.owner)
                 break
     
     def do_attack(self, direction):
         nearPlaces = self.owner.getGround().getNeighbours()
-        if direction == None:
+        if direction is None:
             objs = self.owner.getNearObjects()
         elif direction in nearPlaces:
             objs = nearPlaces[direction].getObjs()
         else:
             return
         for obj in objs:
-            if obj.getComponent("fighter") != None and self.alignment.isEnemy(obj):
+            if obj.getComponent("fighter") is not None and self.alignment.isEnemy(obj):
                 self.fighter.attack(obj)
                 break
     

--- a/asciifarm/server/components/inventory.py
+++ b/asciifarm/server/components/inventory.py
@@ -4,7 +4,9 @@ from ..entity import Entity
 
 class Inventory(Component):
     
-    def __init__(self, capacity, initialItems=[]):
+    def __init__(self, capacity, initialItems=None):
+        if initialItems is None:
+            initialItems = []
         self.capacity = capacity
         self.items = []
         self.owner = None

--- a/asciifarm/server/components/spawner.py
+++ b/asciifarm/server/components/spawner.py
@@ -37,7 +37,7 @@ class Spawner(Component):
                 self.goSpawn()
     
     def goSpawn(self, duration=None):
-        if duration == None:
+        if duration is None:
             duration = self.respawnDelay
         to = timeout.Timeout(self.updateEvent, random.triangular(duration/2, duration*2, duration), callback=self.spawn)
         self.timeouts.add(to)

--- a/asciifarm/server/components/spawner.py
+++ b/asciifarm/server/components/spawner.py
@@ -6,7 +6,11 @@ from .component import Component
 
 class Spawner(Component):
     
-    def __init__(self, objectType, amount=1, respawnDelay=1, setHome=False, initialSpawn=False, objectArgs=[], objectKwargs={}):
+    def __init__(self, objectType, amount=1, respawnDelay=1, setHome=False, initialSpawn=False, objectArgs=None, objectKwargs=None):
+        if objectArgs is None:
+            objectArgs = []
+        if objectKwargs is None:
+            objectKwargs = {}
         self.objectType = objectType
         self.amount = amount
         self.respawnDelay = respawnDelay

--- a/asciifarm/server/entity.py
+++ b/asciifarm/server/entity.py
@@ -81,8 +81,8 @@ class Entity:
         return self.height
     
     def inRoom(self):
-        return self.ground != None
-    
+        return self.ground is not None
+
     def getGround(self):
         return self.ground
     
@@ -112,7 +112,7 @@ class Entity:
     
     @classmethod
     def fromJSON(cls, data):
-        if data == None:
+        if data is None:
             return None
         return cls(
             sprite = data["sprite"],

--- a/asciifarm/server/entity.py
+++ b/asciifarm/server/entity.py
@@ -14,7 +14,11 @@ class Entity:
     Remove methods are for cleanup, like unsubscribing from events.
     """
     
-    def __init__(self, sprite=' ', height=0, name=None, components={}, flags=set()):
+    def __init__(self, sprite=' ', height=0, name=None, components=None, flags=None):
+        if components is None:
+            components = {}
+        if flags is None:
+            flags = set()
         self.sprite = sprite # the name of the image to display for this entity
         self.height = height # if multiple objects are on a square, the tallest one is drawn
         self.name = name if name else sprite # human readable name/description

--- a/asciifarm/server/event.py
+++ b/asciifarm/server/event.py
@@ -7,7 +7,7 @@ class Event:
         self.listeners = {}
     
     def addListener(self, listener, key=None):
-        if key == None:
+        if key is None:
             key = listener
         self.listeners[key] = listener
     

--- a/asciifarm/server/game.py
+++ b/asciifarm/server/game.py
@@ -13,8 +13,10 @@ saveExt = ".save.json"
 
 class Game:
     
-    def __init__(self, socketType, worldData={"begin": None, "rooms": {}}, loadDir=None, saveDir=None, saveInterval=1):
-        
+    def __init__(self, socketType, worldData=None, loadDir=None, saveDir=None, saveInterval=1):
+        if worldData is None:
+            worldData = {"begin": None, "rooms": {}}
+
         self.server = gameserver.GameServer(self, socketType)
         
         

--- a/asciifarm/server/gameobjects.py
+++ b/asciifarm/server/gameobjects.py
@@ -113,7 +113,11 @@ def makeTroll(home=None):
         })
 entities["troll"] = makeTroll
 
-def makeSpawner(objType, number, delay, sprite=None, name=None, height=0, setHome=False, initialSpawn=False, objArgs=[], objKwargs={}):
+def makeSpawner(objType, number, delay, sprite=None, name=None, height=0, setHome=False, initialSpawn=False, objArgs=None, objKwargs=None):
+    if objArgs is None:
+        objArgs = []
+    if objKwargs is None:
+        objKwargs = {}
     return Entity(sprite=sprite, height=height, name=name, components={"spawn": Spawner(objType, number, delay, setHome, initialSpawn, objArgs, objKwargs)})
 entities["spawner"] = makeSpawner
 

--- a/asciifarm/server/grid.py
+++ b/asciifarm/server/grid.py
@@ -10,7 +10,7 @@ class Grid:
         self.clear(default)
     
     def clear(self, value):
-        self.grid = [value for i in range(self.width*self.height)];
+        self.grid = [value for i in range(self.width*self.height)]
     
     def isValid(self, x, y):
         return x>=0 and y>=0 and x<self.width and y<self.height

--- a/asciifarm/server/main.py
+++ b/asciifarm/server/main.py
@@ -30,7 +30,7 @@ def main(argv=None):
     
     args = parser.parse_args(argv)
     address = args.address
-    if address == None:
+    if address is None:
         address = defaultAdresses[args.socket]
     if args.socket == "abstract":
         address = '\0' + address

--- a/asciifarm/server/room.py
+++ b/asciifarm/server/room.py
@@ -11,7 +11,9 @@ from . import roomdata
 class Room:
     
     
-    def __init__(self, name, data, preserved=[]):
+    def __init__(self, name, data, preserved=None):
+        if preserved is None:
+            preserved = []
         self.name = name
         self.width = data["width"]
         self.height = data["height"]

--- a/asciifarm/server/room.py
+++ b/asciifarm/server/room.py
@@ -75,7 +75,7 @@ class Room:
         If the room has been unloaded for a while, it will make a large step next.
         This is useful for allowing plants to grow for example
         """
-        if self.lastStepStamp == None:
+        if self.lastStepStamp is None:
             timePassed = 1
         else:
             timePassed = stepStamp - self.lastStepStamp

--- a/asciifarm/server/roomdata.py
+++ b/asciifarm/server/roomdata.py
@@ -8,8 +8,10 @@ class RoomData:
     The Ground class does this as well, but Ground only gives local data, whereas this give data about the whole room.
     """
     
-    def __init__(self, events=[]):
-        
+    def __init__(self, events=None):
+        if events is None:
+            events = []
+
         self.events = events
         self.targets = set()
         

--- a/asciifarm/server/socketserver.py
+++ b/asciifarm/server/socketserver.py
@@ -84,7 +84,7 @@ class Server:
     def send(self, connection, msg):
         try:
             send(connection, msg)
-        except:
+        except Exception:
             self.connections.discard(connection)
             self.onConnectionClose(connection)
             print("failed to send to client")


### PR DESCRIPTION
I've made a few changes in separate commits, so you can cherrypick only some of them if preferred:

* Added `.idea` folder to .gitignore - this is PyCharm's project directory
* Fixed mutable default arguments, as discussed on IRC - see commit message for possible alternative
* Replaced None equality checks with identity checks - see commit message for explanation
* Removed a redundant semicolon
* Fixed a couple errors in `client/connection.py`:
    * `data` is potentially used before definition if there's an exception while receiving it
    * `sockType` won't exist if `socketType` isn't one of the checked options

Other things:

* Many (if not all) components set `self.owner` inside `attach()`, but it isn't set anywhere else. This should probably be set to `None` in `__init__()` so that `self.owner` always at least exists. I'm not sure if this is something that every component should do, or if it should just be done in `Component`. I would do the latter, given that it seems all (or almost all) components set it anyway, but I wasn't sure what you'd rather.
There are some other attributes that get created for the first time in `attach()` too, but those are component-specific, so those would be set to `None` in the respective components' `__init__`s.
This isn't a major issue, as the only practical difference is using this code wrongly would give a slightly different error than it currently does, but it is a code smell, so thought I should point it out.
* `(i)` is the same as `i` - it does not create a tuple containing `i`. For that, you would need `(i,)`. This is because otherwise parentheses couldn't be used to organise code. In cases like `"%s" % (i)`, you can just do `"%s" % i` - these are equivalent. If `i` may be a tuple itself, you'd want to do `"%s" % (i,)`.
In fact, parentheses are not required for tuples at all - it is the comma that creates them, and the parentheses are just there to disambiguate it from, say, two separate arguments. In cases such as `return (a, b)`, you can just do `return a, b`.
Note: There is one special case - `()` creates an empty tuple, rather than just being structural parentheses.
* When you want to catch all exceptions, you generally want to use `except Exception:` rather than just `except:`. This is because things such as Ctrl-C work by raising an exception, and can end up getting caught at random parts of your code - if you use the latter snippet, you won't catch these types of exceptions and Ctrl-C will successfully propagate up the stack and close the program (or hit an actual handler for keyboard interrupts).
The reason it works this way is because there is a base exception class called `BaseException`, which has a subclass called `Exception`. Almost every exception, such as `ValueError` and `KeyError`, are subclasses of `Exception`. Exceptions that aren't really program exceptions and more system expressions, such as `KeyboardInterrupt` and `SystemExit`, are subclasses of `BaseException`, as you generally don't want to catch these.
I haven't fixed this because you've only got it in one place (`server/socketserver.py`), and didn't notice it before making this PR.
* You have a few unused imports in some files. These aren't hurting, but it's generally a good idea to clean these up. A lot of these are `curses` imports, so I'm assuming they're left over from when more things called curses directly.
* There are a couple of unused variables that I'm not sure if are leftovers, or if they're mistakenly not used.
    * `server/room.py` - The `preserved` parameter in `Room.__init__` isn't actually stored (or used anywhere) - does this need to exist?
    * `server/inputcontroller.py` - `InputController.do_interact` has a variable `nearPlaces`, but then gets another list of nearby objects and uses that instead - can this be removed?