### PR TITLE
xcv correspond to ground, inventory, equipment

### DIFF
--- a/asciifarm/keybindings/keybindings.hy
+++ b/asciifarm/keybindings/keybindings.hy
@@ -21,9 +21,9 @@ r (do [
     (inp ["interact" "south"])
     (inp ["interact" "east"])
     (inp ["interact" "west"])])
-v (.select (selector "inventory") 1 True True)
-c (.select (selector "ground") 1 True True)
-x (.select (selector "equipment") 1 True True)
+c (.select (selector "inventory") 1 True True)
+x (.select (selector "ground") 1 True True)
+v (.select (selector "equipment") 1 True True)
 z (inp ["unequip" (selectorvalue "equipment")])
 f (do [
     (inp ["attack"])


### PR DESCRIPTION
xcv now correspond to ground, inventory, equipment. This is the same as
their top-down order displayed in asciifarm’s ui’s sidebar.